### PR TITLE
BFT feature: units with devices are tracked - not groups

### DIFF
--- a/lib/bft_light/fn_bftdialog.sqf
+++ b/lib/bft_light/fn_bftdialog.sqf
@@ -122,12 +122,14 @@ BG_fnc_bftdialog_editButton = {
         if (ctrlShown BG_UI_BFT_ctrlGroup) then {
             BG_UI_BFT_ctrlGroup ctrlShow false;
             BG_UI_BFT_editButton ctrlSetText "ID";
-            group player setGroupIdGlobal [ctrlText BG_UI_BFT_tbName];
-            group player setVariable ["BG_BFT_groupId", ctrlText BG_UI_BFT_tbName,true];
-            group player setVariable ["BG_BFT_icon", (BG_UI_BFT_lbIcon lbData lbCurSel BG_UI_BFT_lbIcon),true];
-            group player setVariable ["BG_BFT_radioSR", ctrlText BG_UI_BFT_tbRadioSR,true];
-            group player setVariable ["BG_BFT_radioLR", ctrlText BG_UI_BFT_tbRadioLR,true];
-            group player setVariable ["BG_BFT_remarks", ctrlText BG_UI_BFT_tbRemarks,true];
+            if (leader player == player) then {
+                group player setGroupIdGlobal [ctrlText BG_UI_BFT_tbName];
+            };
+            player setVariable ["BG_BFT_groupId", ctrlText BG_UI_BFT_tbName,true];
+            player setVariable ["BG_BFT_icon", (BG_UI_BFT_lbIcon lbData lbCurSel BG_UI_BFT_lbIcon),true];
+            player setVariable ["BG_BFT_radioSR", ctrlText BG_UI_BFT_tbRadioSR,true];
+            player setVariable ["BG_BFT_radioLR", ctrlText BG_UI_BFT_tbRadioLR,true];
+            player setVariable ["BG_BFT_remarks", ctrlText BG_UI_BFT_tbRemarks,true];
 
             BG_UI_BFT_ctrlGroup ctrlCommit 0;
             BG_UI_BFT_editButton ctrlCommit 0;
@@ -155,16 +157,16 @@ BG_fnc_bftdialog_editButton = {
 
             BG_UI_BFT_lbIcon ctrlCommit 0;
 
-            BG_UI_BFT_tbName ctrlSetText ((group player) getVariable ["BG_BFT_groupId", (groupId (group player))]);
+            BG_UI_BFT_tbName ctrlSetText (player getVariable ["BG_BFT_groupId", (groupId (group player))]);
             BG_UI_BFT_tbName ctrlCommit 0;
 
-            BG_UI_BFT_tbRemarks ctrlSetText ((group player) getVariable ["BG_BFT_remarks", ""]);
+            BG_UI_BFT_tbRemarks ctrlSetText (player getVariable ["BG_BFT_remarks", ""]);
             BG_UI_BFT_tbRemarks ctrlCommit 0;
 
-            BG_UI_BFT_tbRadioSR ctrlSetText ((group player) getVariable ["BG_BFT_radioSR", "n/a"]);
+            BG_UI_BFT_tbRadioSR ctrlSetText (player getVariable ["BG_BFT_radioSR", "n/a"]);
             BG_UI_BFT_tbRadioSR ctrlCommit 0;
 
-            BG_UI_BFT_tbRadioLR ctrlSetText ((group player) getVariable ["BG_BFT_radioLR", "n/a"]);
+            BG_UI_BFT_tbRadioLR ctrlSetText (player getVariable ["BG_BFT_radioLR", "n/a"]);
             BG_UI_BFT_tbRadioLR ctrlCommit 0;
 
             BG_UI_BFT_ctrlGroup ctrlCommit 0;

--- a/lib/bft_light/fn_iconUpdateLoop.sqf
+++ b/lib/bft_light/fn_iconUpdateLoop.sqf
@@ -11,11 +11,10 @@
 private ["_players","_icons","_groups","_defaultIcon","_icon","_text","_textSize","_font","_align","_iconType"];
 
 _icons = [];
-_groups = [];
 _textSize = 0.06;
 _font = "PuristaSemiBold";
 _align = "right";
-_defaultIcon = switch (playerSide) do {
+_defaultIcon = switch (player getVariable ["BG_BFT_playerSide", side _x]) do {
     case (west): {
       "b_unknown"
     };
@@ -32,17 +31,16 @@ _defaultIcon = switch (playerSide) do {
 
 if (BG_BFT_onlyPlayer) then {
     {
-        if (!((group _x) in _groups) && {_x getVariable ["BG_BFT_playerSide", side _x] == playerSide} && {_x getVariable ["BG_BFT_item", 0] > 1}) then {
-            _groups pushBack group _x;
-            _icon = (group _x) getVariable ["BG_BFT_icon", _defaultIcon];
-            _text = (group _x) getVariable ["BG_BFT_groupId", groupId (group _x)];
+        if (_x getVariable ["BG_BFT_playerSide", side _x] == playerSide && {_x getVariable ["BG_BFT_item", 0] > 1}) then {
+            _icon = _x getVariable ["BG_BFT_icon", _defaultIcon];
+            _text = _x getVariable ["BG_BFT_groupId", groupId (group _x)];
             _iconType = (BG_BFT_iconTypes select 0) find _icon;
             if (_iconType >= 0) then {
                 _iconType = (BG_BFT_iconTypes select 1) select _iconType;
                 _icons pushBack [
                     _iconType select 0,
                     _iconType select 1,
-                    leader _x,
+                    _x,
                     _iconType select 2,
                     _iconType select 2,
                     0,
@@ -58,7 +56,7 @@ if (BG_BFT_onlyPlayer) then {
     } count allPlayers;
 } else {
     {
-        if (leader _x getVariable ["BG_BFT_playerSide", side leader _x] == playerSide && {leader _x getVariable ["BG_BFT_item", 0] > 1}) then {
+        if (leader _x getVariable ["BG_BFT_playerSide", side _x] == playerSide && {_x getVariable ["BG_BFT_item", 0] > 1}) then {
             _icon = _x getVariable ["BG_BFT_icon", _defaultIcon];
             _text = _x getVariable ["BG_BFT_groupId", groupId _x];
             _iconType = (BG_BFT_iconTypes select 0) find _icon;
@@ -80,7 +78,7 @@ if (BG_BFT_onlyPlayer) then {
             };
         };
         true
-    } count allGroups;
+    } count allUnits;
 };
 
 BG_BFT_Icons = +_icons;

--- a/lib/bft_light/fn_iconUpdateLoop.sqf
+++ b/lib/bft_light/fn_iconUpdateLoop.sqf
@@ -14,7 +14,7 @@ _icons = [];
 _textSize = 0.06;
 _font = "PuristaSemiBold";
 _align = "right";
-_defaultIcon = switch (player getVariable ["BG_BFT_playerSide", side _x]) do {
+_defaultIcon = switch (playerSide) do {
     case (west): {
       "b_unknown"
     };

--- a/lib/bft_light/fn_mouseMovingEvent.sqf
+++ b/lib/bft_light/fn_mouseMovingEvent.sqf
@@ -35,14 +35,14 @@ _r = 1000;
 if (_r < 0.02) then {
     with uiNamespace do {
         private "_temp";
-        _temp = (group (_group select 2));
+        _temp = (_group select 2);
         BG_UI_BFT_ttRadio ctrlSetText format [
             "SR: %1 | LR: %2",
             _temp getVariable ["BG_BFT_radioSR","n/a"],
             _temp getVariable ["BG_BFT_radioLR","n/a"]
         ];
         BG_UI_BFT_ttRadio ctrlCommit 0;
-        BG_UI_BFT_ttRemarks ctrlSetText ((group (_group select 2)) getVariable ["BG_BFT_remarks",""]);
+        BG_UI_BFT_ttRemarks ctrlSetText ((_group select 2) getVariable ["BG_BFT_remarks",""]);
         BG_UI_BFT_ttRemarks ctrlCommit 0;
         BG_UI_BFT_groupToolTip ctrlSetPosition [_xPos,_yPos];
         BG_UI_BFT_groupToolTip ctrlShow true;


### PR DESCRIPTION
As the title said. Changed the tracking from groups to units. So now it is possible to have multiple BFT devices in one group, which can be tracked independently. (e.g. one squad with sql and tl)
- [x] first implementation
- [x] tested
